### PR TITLE
hoomd-blue version bump

### DIFF
--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -51,7 +51,8 @@ class HoomdBlue(CMakePackage):
     # clone a specific tag from Bitbucket instead of using the tarballs.
     # https://bitbucket.org/glotzer/hoomd-blue/issues/238
     version('2.1.6', git=git, tag='v2.1.6', submodules=True)
-
+    version('2.2.2', git=git, tag='v2.2.2', submodules=True)
+    
     variant('mpi',  default=True,  description='Compile with MPI enabled')
     variant('cuda', default=True,  description='Compile with CUDA Toolkit')
     variant('doc',  default=False, description='Generate documentation')
@@ -61,11 +62,14 @@ class HoomdBlue(CMakePackage):
     # https://gcc.gnu.org/projects/cxx-status.html
     conflicts('%gcc@:4.6')
 
-    # HOOMD-blue uses hexadecimal floats, which are not technically part of
+    # HOOMD-blue 2.1.6 uses hexadecimal floats, which are not technically part of
     # the C++11 standard. GCC 6.0+ produces an error when this happens.
     # https://bitbucket.org/glotzer/hoomd-blue/issues/239
     # https://bugzilla.redhat.com/show_bug.cgi?id=1321986
-    conflicts('%gcc@6.0:')
+    conflicts('%gcc@6.0:', when='@2.1.6')
+    
+    # HOOMD-blue GCC 7+ is not yet supported
+    conflicts('%gcc@7.0:')
 
     extends('python')
     depends_on('python@2.7:')


### PR DESCRIPTION
updated hoomd-blue to latest tagged release in repo.  This version also supports newer gcc6 compilers, so added constraint for older version to avoid breaking existing installs.